### PR TITLE
fix pytorch callbacks

### DIFF
--- a/toolkit/pytorch_transformers/models.py
+++ b/toolkit/pytorch_transformers/models.py
@@ -29,7 +29,7 @@ class Model(BaseTransformer):
         self.optimizer = None
         self.loss_function = None
         self.callbacks = None
-        self.validation_loss = None
+        self.validation_loss = {}
 
     @property
     def output_names(self):


### PR DESCRIPTION
- change `validation_loss` initialization in `Model` so that all callbacks can have references to the same one dict
- change `get_validation_loss` method so that `score_model` is not unnecessarily called (setdafault does not perform lazy evaluation)
- change `EarlyStopping`, because it was writing into `validation_loss` values with wrong epoch_id