### PR TITLE
Allow sklearn transformers without y argument

### DIFF
--- a/toolkit/sklearn_transformers/models.py
+++ b/toolkit/sklearn_transformers/models.py
@@ -16,7 +16,7 @@ class SklearnBaseTransformer(BaseTransformer):
         super().__init__()
         self.estimator = estimator
 
-    def fit(self, X, y, **kwargs):
+    def fit(self, X, y=None, **kwargs):
         self.estimator.fit(X, y)
         return self
 


### PR DESCRIPTION
### Code contributions
Allow sklearn transformers to have no 'y' variable